### PR TITLE
Corrected minor language issues in code documentation

### DIFF
--- a/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
+++ b/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
@@ -488,7 +488,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
+++ b/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
@@ -695,7 +695,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
+++ b/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
@@ -868,7 +868,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
+++ b/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
@@ -902,7 +902,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
+++ b/03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino
@@ -805,7 +805,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/03 Arduino Code/BMSAIT_Vanilla/SwitecX27cont.cpp
+++ b/03 Arduino Code/BMSAIT_Vanilla/SwitecX27cont.cpp
@@ -121,7 +121,7 @@ void SwitecX27::center(unsigned int pos)
 // characteristics of the motor.  Ultimately it 
 // steps the motor once (up or down) and computes
 // the delay until the next step.  Because it gets
-// called once per step per motor, the calcuations
+// called once per step per motor, the calculations
 // here need to be as light-weight as possible, so
 // we are avoiding floating-point arithmetic.
 //

--- a/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
+++ b/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
+++ b/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
+++ b/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
+++ b/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
+++ b/04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
+++ b/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
+++ b/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
+++ b/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
+++ b/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
+++ b/04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
+++ b/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
+++ b/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
+++ b/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
+++ b/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
+++ b/04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
+++ b/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
+++ b/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
+++ b/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
+++ b/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
+++ b/04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
+++ b/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
+++ b/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
+++ b/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
+++ b/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
+++ b/04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
+++ b/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
+++ b/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
+++ b/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
+++ b/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
+++ b/04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
+++ b/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
+++ b/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
+++ b/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
+++ b/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
+++ b/04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
+++ b/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
+++ b/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
+++ b/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
+++ b/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
+++ b/04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
+++ b/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
+++ b/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
+++ b/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
+++ b/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
+++ b/04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
+++ b/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
+++ b/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
+++ b/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
+++ b/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
+++ b/04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
+++ b/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
@@ -776,7 +776,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
+++ b/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
@@ -666,7 +666,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
+++ b/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
@@ -873,7 +873,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
+++ b/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
@@ -839,7 +839,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
+++ b/04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino
@@ -461,7 +461,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
+++ b/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
+++ b/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
+++ b/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
+++ b/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
+++ b/04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
+++ b/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
+++ b/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
+++ b/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
+++ b/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
+++ b/04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/04g Motorpotentiometer/Arduino Sketch/Motorpot_test/Motorpot_test.ino
+++ b/04 examples/04g Motorpotentiometer/Arduino Sketch/Motorpot_test/Motorpot_test.ino
@@ -375,7 +375,7 @@ void loop()
 {
   long curr_time=millis();
   
-  if (!error) //only continue if no error occured
+  if (!error) //only continue if no error occurred
   {  
     //check for debug message (set new trim pos)
     ReadMessage(); 

--- a/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
+++ b/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
+++ b/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
+++ b/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
+++ b/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
+++ b/04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
+++ b/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
+++ b/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
+++ b/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
+++ b/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
+++ b/04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
+++ b/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
+++ b/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
+++ b/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
+++ b/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
+++ b/04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
+++ b/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
+++ b/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
+++ b/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
+++ b/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
+++ b/04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
+++ b/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
+++ b/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
+++ b/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
+++ b/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
+++ b/04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
+++ b/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
+++ b/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
@@ -816,7 +816,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
+++ b/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
@@ -850,7 +850,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
+++ b/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
@@ -444,7 +444,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
+++ b/04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino
@@ -753,7 +753,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -666,7 +666,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -883,7 +883,7 @@ void ReadResponse()
   }
 }
             
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -841,7 +841,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -647,7 +647,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -778,7 +778,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino
@@ -464,7 +464,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -666,7 +666,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -883,7 +883,7 @@ void ReadResponse()
   }
 }
             
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -841,7 +841,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -458,7 +458,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -647,7 +647,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -455,7 +455,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -778,7 +778,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino
@@ -464,7 +464,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -666,7 +666,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -883,7 +883,7 @@ void ReadResponse()
   }
 }
             
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -841,7 +841,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -458,7 +458,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -647,7 +647,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -643,7 +643,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -455,7 +455,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -778,7 +778,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
+++ b/04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino
@@ -464,7 +464,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -654,7 +654,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -459,7 +459,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -846,7 +846,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -880,7 +880,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -468,7 +468,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -462,7 +462,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -650,7 +650,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -673,7 +673,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
+++ b/04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino
@@ -783,7 +783,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -674,7 +674,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -651,7 +651,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -856,7 +856,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -655,7 +655,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -469,7 +469,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -463,7 +463,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -460,7 +460,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -953,7 +953,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
+++ b/04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino
@@ -919,7 +919,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -660,7 +660,7 @@ void PullRequest(byte var)
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT
-      UpdateInput();   //throw in another update if inputs are priorized
+      UpdateInput();   //throw in another update if inputs are prioritized
       x+=10;
     #endif
     delay(1);

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -853,7 +853,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -656,7 +656,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
     #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput(); //throw in another update if outputs are priorized
+      UpdateOutput(); //throw in another update if outputs are prioritized
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -887,7 +887,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -467,7 +467,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -473,7 +473,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -679,7 +679,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -790,7 +790,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved																							  
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received																							  
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino
@@ -464,7 +464,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -660,7 +660,7 @@ void PullRequest(byte var)
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT
-      UpdateInput();   //throw in another update if inputs are priorized
+      UpdateInput();   //throw in another update if inputs are prioritized
       x+=10;
     #endif
     delay(1);

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -853,7 +853,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -656,7 +656,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
     #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput(); //throw in another update if outputs are priorized
+      UpdateOutput(); //throw in another update if outputs are prioritized
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -887,7 +887,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -467,7 +467,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -473,7 +473,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -679,7 +679,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -790,7 +790,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved																							  
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received																							  
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino
@@ -464,7 +464,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -660,7 +660,7 @@ void PullRequest(byte var)
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT
-      UpdateInput();   //throw in another update if inputs are priorized
+      UpdateInput();   //throw in another update if inputs are prioritized
       x+=10;
     #endif
     delay(1);

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -853,7 +853,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -656,7 +656,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
     #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput(); //throw in another update if outputs are priorized
+      UpdateOutput(); //throw in another update if outputs are prioritized
       x+=10;
     #endif
     #ifdef PRIORITIZE_INPUT

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -887,7 +887,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -467,7 +467,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -473,7 +473,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -679,7 +679,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -790,7 +790,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved																							  
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received																							  
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
+++ b/04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino
@@ -464,7 +464,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
+++ b/04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
+++ b/04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -787,7 +787,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -467,7 +467,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -473,7 +473,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -677,7 +677,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -464,7 +464,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -850,7 +850,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -884,7 +884,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -654,7 +654,7 @@ void PullRequest(byte var)
     while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
     {
       #ifdef PRIORITIZE_OUTPUT
-        UpdateOutput(); //throw in another update if outputs are priorized
+        UpdateOutput(); //throw in another update if outputs are prioritized
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT

--- a/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
+++ b/04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino
@@ -658,7 +658,7 @@ void PullRequest(byte var)
         x+=10;
       #endif
       #ifdef PRIORITIZE_INPUT
-        UpdateInput();   //throw in another update if inputs are priorized
+        UpdateInput();   //throw in another update if inputs are prioritized
         x+=10;
       #endif
       delay(1);

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
+++ b/04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
+++ b/04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/SwitecX27cont.cpp
+++ b/04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/SwitecX27cont.cpp
@@ -121,7 +121,7 @@ void SwitecX27::center(unsigned int pos)
 // characteristics of the motor.  Ultimately it 
 // steps the motor once (up or down) and computes
 // the delay until the next step.  Because it gets
-// called once per step per motor, the calcuations
+// called once per step per motor, the calculations
 // here need to be as light-weight as possible, so
 // we are avoiding floating-point arithmetic.
 //

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -485,7 +485,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -672,7 +672,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -864,7 +864,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -476,7 +476,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -668,7 +668,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -801,7 +801,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -898,7 +898,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -479,7 +479,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino
@@ -691,7 +691,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -488,7 +488,7 @@ void ReadData()
     }   
     if (millis()-POLLTIME>lastPoll) //reduce the number of attempts to get new data (default POLLTIME 200 --> max of 5 attempts per second)
     {
-      SendMessage("",5); // reqest new data
+      SendMessage("",5); // request new data
       lastPoll=millis();
     }       
   }

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -482,7 +482,7 @@ void ReadData()
       UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
-      UpdateInput(false);   //throw in another update if inputs are priorized 
+      UpdateInput(false);   //throw in another update if inputs are prioritized 
       #endif
       ReadResponse();   //check for new data from the windows app
     }   

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -696,7 +696,7 @@ void PullRequest(byte var)
 void Reset()
 {
   while (SERIALCOM.available()){SERIALCOM.read();}
-  SendMessage("",5); // reqest new data
+  SendMessage("",5); // request new data
   state=0;
 }
 

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -869,7 +869,7 @@ void ReadResponse()
             int laenge=sizeof(neuer_wert.wert);            
             if (neuer_wert.varNr<100)     //only compute the data if a valid data position is found (everything above 99 is invalid)
             {
-              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the recieved data is different from the stored data
+              if (strcmp(datenfeld[neuer_wert.varNr].wert, neuer_wert.wert)!=0)  //check if the received data is different from the stored data
               {
                 for (int lauf=DATENLAENGE-1;lauf>laenge;lauf--)
                   {datenfeld[neuer_wert.varNr].wert[lauf]='\0';}

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -673,7 +673,7 @@ void PullRequest(byte var)
   while ((SERIALCOM.available()<3) && (x<PULLTIMEOUT)) //wait for answer, but no longer than 30ms
   {
 	#ifdef PRIORITIZE_OUTPUT
-	  UpdateOutput(); //throw in another update if outputs are priorized
+	  UpdateOutput(); //throw in another update if outputs are prioritized
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -806,7 +806,7 @@ void ReadResponse()
     if ((state==1) && SERIALCOM.available())
     {
       inputByte_1=SERIALCOM.read();
-      if (!CheckForSysCommand(inputByte_1))  //check if a system command was recieved. If not, continue to check if valid data was recieved
+      if (!CheckForSysCommand(inputByte_1))  //check if a system command was received. If not, continue to check if valid data was received
       {
         if (((int)inputByte_1 < variableCount) || ((int)inputByte_1 >100)) //check if ID is valid
         {

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -479,7 +479,7 @@ void ReadData()
     while(SERIALCOM.available())
     { 
       #ifdef PRIORITIZE_OUTPUT
-      UpdateOutput();   //throw in another update if outputs are priorized 
+      UpdateOutput();   //throw in another update if outputs are prioritized 
       #endif
       #ifdef PRIORITIZE_INPUT
       UpdateInput(false);   //throw in another update if inputs are priorized 

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -903,7 +903,7 @@ void ReadResponse()
   }
 }
 
-//readback of recieved data for verification
+//readback of received data for verification
 void DebugReadback(byte posID)
 {
   char antwort[DATENLAENGE+3]="";

--- a/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
+++ b/04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino
@@ -677,7 +677,7 @@ void PullRequest(byte var)
 	  x+=10;
 	#endif
 	#ifdef PRIORITIZE_INPUT
-	  UpdateInput();   //throw in another update if inputs are priorized
+	  UpdateInput();   //throw in another update if inputs are prioritized
 	  x+=10;
 	#endif
 	delay(1);


### PR DESCRIPTION
Improved text accuracy by fixing minor typos.

### Fix overview:
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 1: `recieve` → `receive`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 1: `recieve` → `receive`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 1: `recieve` → `receive`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 1: `recieve` → `receive`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 1: `recieve` → `receive`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 1: `recieve` → `receive`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 1: `recieve` → `receive`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 1: `recieve` → `receive`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 1: `recieve` → `receive`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 1: `recieve` → `receive`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 1: `recieve` → `receive`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 1: `recieve` → `receive`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 1: `recieve` → `receive`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 1: `recieve` → `receive`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 1: `recieve` → `receive`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 1: `recieve` → `receive`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 1: `recieve` → `receive`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 1: `recieve` → `receive`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 1: `recieve` → `receive`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 1: `recieve` → `receive`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 1: `recieve` → `receive`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 1: `recieve` → `receive`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 1: `recieve` → `receive`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 1: `recieve` → `receive`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 1: `recieve` → `receive`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 1: `recieve` → `receive`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 1: `recieve` → `receive`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 1: `recieve` → `receive`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 1: `recieve` → `receive`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 1: `recieve` → `receive`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 1: `recieve` → `receive`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 1: `recieve` → `receive`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 1: `recieve` → `receive`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 1: `recieve` → `receive`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 1: `recieve` → `receive`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 1: `recieve` → `receive`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 1: `recieve` → `receive`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 13: `inital` → `initial`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 13: `inital` → `initial`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 13: `inital` → `initial`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 13: `inital` → `initial`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 13: `inital` → `initial`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 13: `inital` → `initial`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 13: `inital` → `initial`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 13: `inital` → `initial`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 13: `inital` → `initial`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 13: `inital` → `initial`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 13: `inital` → `initial`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 13: `inital` → `initial`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 13: `inital` → `initial`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 13: `inital` → `initial`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 13: `inital` → `initial`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 13: `inital` → `initial`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 13: `inital` → `initial`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 13: `inital` → `initial`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 13: `inital` → `initial`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 13: `inital` → `initial`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 13: `inital` → `initial`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 13: `inital` → `initial`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 13: `inital` → `initial`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 13: `inital` → `initial`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 13: `inital` → `initial`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 13: `inital` → `initial`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 13: `inital` → `initial`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 13: `inital` → `initial`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 13: `inital` → `initial`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 13: `inital` → `initial`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 13: `inital` → `initial`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 17: `inital` → `initial`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 13: `inital` → `initial`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 13: `inital` → `initial`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 13: `inital` → `initial`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 13: `inital` → `initial`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 13: `inital` → `initial`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 45: `adress` → `address`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 45: `adress` → `address`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 45: `adress` → `address`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 45: `adress` → `address`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 45: `adress` → `address`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 45: `adress` → `address`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 45: `adress` → `address`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 45: `adress` → `address`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 45: `adress` → `address`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 45: `adress` → `address`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 45: `adress` → `address`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 45: `adress` → `address`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 45: `adress` → `address`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 45: `adress` → `address`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 45: `adress` → `address`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 45: `adress` → `address`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 45: `adress` → `address`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 45: `adress` → `address`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 45: `adress` → `address`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 45: `adress` → `address`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 45: `adress` → `address`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 45: `adress` → `address`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 45: `adress` → `address`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 45: `adress` → `address`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 45: `adress` → `address`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 45: `adress` → `address`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 45: `adress` → `address`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 45: `adress` → `address`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 45: `adress` → `address`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 45: `adress` → `address`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 45: `adress` → `address`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 49: `adress` → `address`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 45: `adress` → `address`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 45: `adress` → `address`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 45: `adress` → `address`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 45: `adress` → `address`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 45: `adress` → `address`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 482: `priorized` → `prioritized`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 485: `priorized` → `prioritized`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 675: `priorized` → `prioritized`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 679: `priorized` → `prioritized`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 438: `priorized` → `prioritized`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 441: `priorized` → `prioritized`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 623: `priorized` → `prioritized`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 627: `priorized` → `prioritized`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 438: `priorized` → `prioritized`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 441: `priorized` → `prioritized`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 623: `priorized` → `prioritized`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 627: `priorized` → `prioritized`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 438: `priorized` → `prioritized`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 441: `priorized` → `prioritized`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 623: `priorized` → `prioritized`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 627: `priorized` → `prioritized`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 438: `priorized` → `prioritized`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 441: `priorized` → `prioritized`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 623: `priorized` → `prioritized`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 627: `priorized` → `prioritized`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 438: `priorized` → `prioritized`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 441: `priorized` → `prioritized`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 623: `priorized` → `prioritized`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 627: `priorized` → `prioritized`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 438: `priorized` → `prioritized`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 441: `priorized` → `prioritized`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 623: `priorized` → `prioritized`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 627: `priorized` → `prioritized`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 438: `priorized` → `prioritized`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 441: `priorized` → `prioritized`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 623: `priorized` → `prioritized`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 455: `priorized` → `prioritized`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 458: `priorized` → `prioritized`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 646: `priorized` → `prioritized`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 650: `priorized` → `prioritized`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 627: `priorized` → `prioritized`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 438: `priorized` → `prioritized`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 441: `priorized` → `prioritized`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 623: `priorized` → `prioritized`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 627: `priorized` → `prioritized`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 438: `priorized` → `prioritized`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 441: `priorized` → `prioritized`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 623: `priorized` → `prioritized`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 627: `priorized` → `prioritized`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 438: `priorized` → `prioritized`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 441: `priorized` → `prioritized`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 623: `priorized` → `prioritized`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 627: `priorized` → `prioritized`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 438: `priorized` → `prioritized`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 441: `priorized` → `prioritized`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 623: `priorized` → `prioritized`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 627: `priorized` → `prioritized`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 438: `priorized` → `prioritized`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 441: `priorized` → `prioritized`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 623: `priorized` → `prioritized`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 627: `priorized` → `prioritized`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 438: `priorized` → `prioritized`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 441: `priorized` → `prioritized`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 623: `priorized` → `prioritized`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 627: `priorized` → `prioritized`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 438: `priorized` → `prioritized`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 441: `priorized` → `prioritized`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 623: `priorized` → `prioritized`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 627: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 458: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 461: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 646: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 650: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 458: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 461: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 646: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 650: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 458: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 461: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 646: `priorized` → `prioritized`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 650: `priorized` → `prioritized`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 462: `priorized` → `prioritized`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 465: `priorized` → `prioritized`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 653: `priorized` → `prioritized`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 657: `priorized` → `prioritized`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 463: `priorized` → `prioritized`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 466: `priorized` → `prioritized`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 654: `priorized` → `prioritized`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 658: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 467: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 470: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 659: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 663: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 467: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 470: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 659: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 663: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 467: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 470: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 659: `priorized` → `prioritized`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 663: `priorized` → `prioritized`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 479: `priorized` → `prioritized`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 482: `priorized` → `prioritized`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 671: `priorized` → `prioritized`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 675: `priorized` → `prioritized`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 479: `priorized` → `prioritized`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 482: `priorized` → `prioritized`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 671: `priorized` → `prioritized`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 675: `priorized` → `prioritized`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 467: `priorized` → `prioritized`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 470: `priorized` → `prioritized`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 657: `priorized` → `prioritized`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 661: `priorized` → `prioritized`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 479: `priorized` → `prioritized`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 482: `priorized` → `prioritized`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 671: `priorized` → `prioritized`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 675: `priorized` → `prioritized`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 479: `priorized` → `prioritized`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 482: `priorized` → `prioritized`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 671: `priorized` → `prioritized`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 675: `priorized` → `prioritized`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 479: `priorized` → `prioritized`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 482: `priorized` → `prioritized`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 671: `priorized` → `prioritized`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 675: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 479: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 482: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 671: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 675: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 482: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 485: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 676: `priorized` → `prioritized`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 680: `priorized` → `prioritized`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 491: `reqest` → `request`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 698: `reqest` → `request`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 447: `reqest` → `request`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 646: `reqest` → `request`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 447: `reqest` → `request`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 646: `reqest` → `request`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 447: `reqest` → `request`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 646: `reqest` → `request`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 447: `reqest` → `request`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 646: `reqest` → `request`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 447: `reqest` → `request`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 646: `reqest` → `request`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 447: `reqest` → `request`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 646: `reqest` → `request`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 447: `reqest` → `request`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 646: `reqest` → `request`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 447: `reqest` → `request`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 646: `reqest` → `request`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 447: `reqest` → `request`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 646: `reqest` → `request`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 447: `reqest` → `request`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 646: `reqest` → `request`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 464: `reqest` → `request`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 669: `reqest` → `request`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 447: `reqest` → `request`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 646: `reqest` → `request`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 447: `reqest` → `request`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 646: `reqest` → `request`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 447: `reqest` → `request`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 646: `reqest` → `request`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 447: `reqest` → `request`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 646: `reqest` → `request`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 447: `reqest` → `request`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 646: `reqest` → `request`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 447: `reqest` → `request`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 646: `reqest` → `request`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 447: `reqest` → `request`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 646: `reqest` → `request`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 447: `reqest` → `request`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 646: `reqest` → `request`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 447: `reqest` → `request`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 646: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 467: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 669: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 467: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 669: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 467: `reqest` → `request`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 669: `reqest` → `request`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 471: `reqest` → `request`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 676: `reqest` → `request`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 472: `reqest` → `request`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 677: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 476: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 682: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 476: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 682: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 476: `reqest` → `request`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 682: `reqest` → `request`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 488: `reqest` → `request`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 694: `reqest` → `request`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 488: `reqest` → `request`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 694: `reqest` → `request`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 476: `reqest` → `request`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 680: `reqest` → `request`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 488: `reqest` → `request`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 694: `reqest` → `request`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 488: `reqest` → `request`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 694: `reqest` → `request`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 488: `reqest` → `request`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 694: `reqest` → `request`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 488: `reqest` → `request`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 694: `reqest` → `request`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 491: `reqest` → `request`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 699: `reqest` → `request`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 808: `recieved` → `received`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 871: `recieved` → `received`
- `03 Arduino Code/BMSAIT_Vanilla/BMSAIT_Vanilla.ino`, line 905: `recieved` → `received`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 756: `recieved` → `received`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 819: `recieved` → `received`
- `04 examples/01a LED Standard/Arduino Sketch/BMSAIT_LED/BMSAIT_LED.ino`, line 853: `recieved` → `received`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 756: `recieved` → `received`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 819: `recieved` → `received`
- `04 examples/01b LED Matrix/Arduino Sketch/BMSAIT_LEDMatrix/BMSAIT_LEDMatrix.ino`, line 853: `recieved` → `received`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 756: `recieved` → `received`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 819: `recieved` → `received`
- `04 examples/02a LCD Standard/Arduino Sketch/BMSAIT_LCD/BMSAIT_LCD.ino`, line 853: `recieved` → `received`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 756: `recieved` → `received`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 819: `recieved` → `received`
- `04 examples/02b OLED display/Arduino Sketch/BMSAIT_OLED/BMSAIT_OLED.ino`, line 853: `recieved` → `received`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 756: `recieved` → `received`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 819: `recieved` → `received`
- `04 examples/02c DotMatrix display/Arduino Sketch/BMSAIT_DotMatrix/BMSAIT_DotMatrix.ino`, line 853: `recieved` → `received`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 756: `recieved` → `received`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 819: `recieved` → `received`
- `04 examples/03a Max7219/Arduino Sketch/BMSAIT_Max7219/BMSAIT_Max7219.ino`, line 853: `recieved` → `received`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 756: `recieved` → `received`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 819: `recieved` → `received`
- `04 examples/03b TM1637/Arduino Sketch/BMSAIT_TM1637/BMSAIT_TM1637.ino`, line 853: `recieved` → `received`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 756: `recieved` → `received`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 819: `recieved` → `received`
- `04 examples/04a Stepper 28BYJ-48/Arduino Sketch/BMSAIT_StepperBYJ/BMSAIT_StepperBYJ.ino`, line 853: `recieved` → `received`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 756: `recieved` → `received`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 819: `recieved` → `received`
- `04 examples/04b Stepper x27-168/Arduino Sketch/BMSAIT_StepperX27/BMSAIT_StepperX27.ino`, line 853: `recieved` → `received`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 756: `recieved` → `received`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 819: `recieved` → `received`
- `04 examples/04c Stepper VID6606/Arduino Sketch/BMSAIT_StepperVID/BMSAIT_StepperVID.ino`, line 853: `recieved` → `received`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 779: `recieved` → `received`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 842: `recieved` → `received`
- `04 examples/04d AirCore Motor/Arduino Sketch/BMSAIT_AirCoreDemo/BMSAIT_AirCoreDemo.ino`, line 876: `recieved` → `received`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 756: `recieved` → `received`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 819: `recieved` → `received`
- `04 examples/04e Servo Motor direkt/Arduino Sketch/BMSAIT_Servo/BMSAIT_Servo.ino`, line 853: `recieved` → `received`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 756: `recieved` → `received`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 819: `recieved` → `received`
- `04 examples/04f Servo Motor Shield/Arduino Sketch/BMSAIT_ServoPWM/BMSAIT_ServoPWM.ino`, line 853: `recieved` → `received`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 756: `recieved` → `received`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 819: `recieved` → `received`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/BMSAIT_MotorPoti/BMSAIT_MotorPoti.ino`, line 853: `recieved` → `received`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 756: `recieved` → `received`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 819: `recieved` → `received`
- `04 examples/08a Switches/Arduino Sketch/BMSAIT_Switches/BMSAIT_Switches.ino`, line 853: `recieved` → `received`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 756: `recieved` → `received`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 819: `recieved` → `received`
- `04 examples/08b Buttonmatrix/Arduino Sketch/BMSAIT_DemoMatrix/BMSAIT_DemoMatrix.ino`, line 853: `recieved` → `received`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 756: `recieved` → `received`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 819: `recieved` → `received`
- `04 examples/08c Analogachse/Arduino Sketch/BMSAIT_AnalogAchse/BMSAIT_AnalogAchse.ino`, line 853: `recieved` → `received`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 756: `recieved` → `received`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 819: `recieved` → `received`
- `04 examples/08d Encoder/Arduino Sketch/BMSAIT_Encoder/BMSAIT_Encoder.ino`, line 853: `recieved` → `received`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 756: `recieved` → `received`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 819: `recieved` → `received`
- `04 examples/08e Magnetic Switches/Arduino Sketch/BMSAIT_MagSwitch/BMSAIT_MagSwitch.ino`, line 853: `recieved` → `received`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 756: `recieved` → `received`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 819: `recieved` → `received`
- `04 examples/09a_Backlighting/Arduino Sketch/BMSAIT_Backlighting/BMSAIT_Backlighting.ino`, line 853: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 781: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 844: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV1/BMSAIT_BUPRadioV1.ino`, line 886: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 781: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 844: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV2/BMSAIT_BUPRadioV2.ino`, line 886: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 781: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 844: `recieved` → `received`
- `04 examples/51 Backup UHF Radio/Arduino Sketch/BMSAIT_BUPRadioV3/BMSAIT_BUPRadioV3.ino`, line 886: `recieved` → `received`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 786: `recieved` → `received`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 849: `recieved` → `received`
- `04 examples/52 Electrics Panel/Arduino Sketch/BMSAIT_DemoElecP/BMSAIT_DemoElecP.ino`, line 883: `recieved` → `received`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 859: `recieved` → `received`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 922: `recieved` → `received`
- `04 examples/53 Trim Panel/Arduino Sketch/BMSAIT_DemoTrimPanel/BMSAIT_DemoTrimPanel.ino`, line 956: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 793: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 856: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV1/BMSAIT_CMDSV1.ino`, line 890: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 793: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 856: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV2/BMSAIT_CMDSV2.ino`, line 890: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 793: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 856: `recieved` → `received`
- `04 examples/54 CMDS Panel/Arduino Sketch/BMSAIT_CMDSV3/BMSAIT_CMDSV3.ino`, line 890: `recieved` → `received`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 804: `recieved` → `received`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 867: `recieved` → `received`
- `04 examples/55 OLED FuelFlowIndicator/Arduino Sketch/BMSAIT_FF/BMSAIT_FF.ino`, line 901: `recieved` → `received`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 804: `recieved` → `received`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 867: `recieved` → `received`
- `04 examples/56 ECM Panel/Arduino Sketch/BMSAIT_ECM/BMSAIT_ECM.ino`, line 901: `recieved` → `received`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 790: `recieved` → `received`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 853: `recieved` → `received`
- `04 examples/57 DED PFL/Arduino Sketch/BMSAIT_DED/BMSAIT_DED.ino`, line 887: `recieved` → `received`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 804: `recieved` → `received`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 867: `recieved` → `received`
- `04 examples/58 SBI OLED/Arduino Sketch/BMSAIT_SBI/BMSAIT_SBI.ino`, line 901: `recieved` → `received`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 804: `recieved` → `received`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 867: `recieved` → `received`
- `04 examples/59 SBI Servo/Arduino Sketch/BMSAIT_SBIServo/BMSAIT_SBIServo.ino`, line 901: `recieved` → `received`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 804: `recieved` → `received`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 867: `recieved` → `received`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/BMSAIT_Compass.ino`, line 901: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 804: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 867: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass1/BMSAIT_OLED_Compass1.ino`, line 901: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 809: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 872: `recieved` → `received`
- `04 examples/61 Wet Compass OLED/Arduino Sketch/BMSAIT_OLED_Compass2/BMSAIT_OLED_Compass2.ino`, line 906: `recieved` → `received`
- `03 Arduino Code/BMSAIT_Vanilla/SwitecX27cont.cpp`, line 124: `calcuations` → `calculations`
- `04 examples/60 Wet Compass X27/Arduino Sketch/BMSAIT_Compass/SwitecX27cont.cpp`, line 124: `calcuations` → `calculations`
- `04 examples/04g Motorpotentiometer/Arduino Sketch/Motorpot_test/Motorpot_test.ino`, line 378: `occured` → `occurred`

All changes are non-functional in nature.